### PR TITLE
Bugfix: functions now callable in blueprints

### DIFF
--- a/Source/CrushDepth/GS_Core.cpp
+++ b/Source/CrushDepth/GS_Core.cpp
@@ -3,19 +3,15 @@
 
 #include "GS_Core.h"
 
-AGS_Core::AGS_Core() {
-    this->CurrentSubmarineHealth = this->SubmarineStartHealth;
-    UE_LOG(LogTemp, Warning, TEXT("Current Submarine Health: %f"), this->CurrentSubmarineHealth)
-}
 
 float AGS_Core::GetSubmarineHealth() {
-    return this->CurrentSubmarineHealth;
+    return CurrentSubmarineHealth;
 };
 
 void AGS_Core::SetSubmarineHealth(float NewHealth) {
-    this->CurrentSubmarineHealth = std::max(0.f, std::min(NewHealth, SubmarineStartHealth));
+    CurrentSubmarineHealth = std::max(0.f, std::min(NewHealth, SubmarineStartHealth));
 };
 
 void AGS_Core::SubtractSubmarineHealth(float Amount) {
-    this->SetSubmarineHealth(this->CurrentSubmarineHealth - Amount);
+    SetSubmarineHealth(CurrentSubmarineHealth - Amount);
 };

--- a/Source/CrushDepth/GS_Core.h
+++ b/Source/CrushDepth/GS_Core.h
@@ -14,18 +14,17 @@ class CRUSHDEPTH_API AGS_Core : public AGameStateBase
 {
 	GENERATED_BODY()
 	
-private:
-	float CurrentSubmarineHealth;
 
 public:
-	float SubmarineStartHealth = 100.f;
-	
-	AGS_Core();
+	static constexpr float SubmarineStartHealth = 100.f;
+	static inline float CurrentSubmarineHealth = SubmarineStartHealth;
+
+	AGS_Core() = default;
 
 	UFUNCTION(BlueprintCallable, Category="Submarine")
-	float GetSubmarineHealth();
+	static float GetSubmarineHealth();
 	UFUNCTION(BlueprintCallable, Category = "Submarine")
-	void SetSubmarineHealth(float NewHealth);
+	static void SetSubmarineHealth(float NewHealth);
 	UFUNCTION(BlueprintCallable, Category = "Submarine")
-	void SubtractSubmarineHealth(float Amount);
+	static void SubtractSubmarineHealth(float Amount);
 };


### PR DESCRIPTION
This PR makes the classes I wrote in #18 static which makes the functions actually callable within blueprints without a reference to the class.

To use the functions, you first must compile the C++ code with Live Coding (Ctrl + Alt + F11). Once this is done, you can simply search for `submarine` to call functions.
![submarine](https://github.com/MasterOfCubesAU/CrushDepth/assets/38149391/b3348ec5-94ce-466a-ba18-526fcf305b1b)
