### PR TITLE
Added money distribution

### DIFF
--- a/Config/GlobalVariables.ini
+++ b/Config/GlobalVariables.ini
@@ -6,7 +6,7 @@ SubmarineDescentRate=4.0
 [Player]
 Money=100.0
 PlayerSpeed=100.0
-MoneyGenerationRate=100.0
+MoneyGenerationRate=2.0
 
 [Environment]
 TaskSpawnRate=100.0

--- a/Source/CrushDepth/CD_PlayerState.h
+++ b/Source/CrushDepth/CD_PlayerState.h
@@ -23,8 +23,10 @@ public:
 	PlayerStates GetPlayerState();
 	UFUNCTION(BlueprintCallable)
 	void SetPlayerState(PlayerStates NewState);
+	UPROPERTY(BlueprintReadWrite)
+	UWallet* wallet;
 
 private:
 	PlayerStates state;
-	UWallet *wallet;
+	
 };

--- a/Source/CrushDepth/GS_Core.cpp
+++ b/Source/CrushDepth/GS_Core.cpp
@@ -86,6 +86,26 @@ void AGS_Core::DoDive() {
     {
         this->CurrentBestAttempt = this->CurrentSubmarineDepth;
     }
+    // Update player money
+    // Don't distribute money if less than midpoint of current best attempt.
+    if (this->CurrentSubmarineState != SubmarineStates::Descending || this->CurrentSubmarineDepth <= this->CurrentBestAttempt / 2.f)
+    {
+        return;
+    }
+    
+    // Iterate through all players and add money
+    for (FConstPlayerControllerIterator iterator = GetWorld()->GetPlayerControllerIterator(); iterator; ++iterator)
+    {
+        APlayerController* Player = Cast<APlayerController>(*iterator);
+        
+        float BaseMoneyRate;
+        GConfig->GetFloat(TEXT("Player"), TEXT("MoneyGenerationRate"), BaseMoneyRate, FPaths::ProjectConfigDir() / TEXT("GlobalVariables.ini"));
+        float AmountToAdd = this->CurrentSubmarineDepth >= this->CurrentBestAttempt / 2.f && this->CurrentSubmarineDepth < this->CurrentBestAttempt ? BaseMoneyRate / 2.0 : BaseMoneyRate;
+
+        // Update Money
+        ((ACD_PlayerState*)Player->PlayerState)->wallet->AddBalance(AmountToAdd);
+    }
+    
 }
 
 void AGS_Core::StartAscent() {

--- a/Source/CrushDepth/GS_Core.h
+++ b/Source/CrushDepth/GS_Core.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/GameStateBase.h"
 #include "SubmarineStatesEnum.h"
+#include "CD_PlayerState.h"
 #include "GS_Core.generated.h"
 
 /**


### PR DESCRIPTION
This PR introduces the distribution of money to all players as the submarine descends.

| Distance Range (Surface to Best Attempt) | Money Distributed |
|---|---|
| 0-50% | 0 |
| 50%-100% | 0.5 * `MoneyGenerationRate` |
| 100%+ | 1 * `MoneyGenerationRate` |